### PR TITLE
Replaced `is not` with `not str.endswith`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 .idea
+test.py

--- a/instamojo/__init__.py
+++ b/instamojo/__init__.py
@@ -1,4 +1,3 @@
 __version__ = '1.1'
 
-from api import Instamojo
-
+from .api import Instamojo

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -24,7 +24,7 @@ class Instamojo:
             raise Exception(response['message']) # TODO: set custom exception?
 
     def links_list(self):
-        response = self._api_call(method='get', path='links')
+        response = self._api_call(method='get', path='links/')
         return response
 
     def link_detail(self, slug):
@@ -113,7 +113,7 @@ class Instamojo:
         return response
 
     def payments_list(self):
-        response = self._api_call(method='get', path='payments')
+        response = self._api_call(method='get', path='payments/')
         return response
 
     def payment_detail(self, payment_id):

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -138,7 +138,7 @@ class Instamojo:
 
         method = method.lower()
         if method not in ['get', 'post', 'delete', 'put', 'patch']:
-            raise Exception('Unable to make a API call for "%s" method.' % method)
+            raise Exception('Unable to make a API call for %r method.' % method)
 
         # Picks up the right function to call (such as requests.get() for 'get')
         api_call = getattr(requests, method)

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -147,7 +147,7 @@ class Instamojo(object):
 
         try:
             return req.json()
-        except:
+        except (TypeError, ValueError):
             raise Exception('Unable to decode response. Expected JSON, got this: \n\n\n %s' % req.text)
 
     def _get_file_upload_url(self):

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -13,7 +13,7 @@ class Instamojo:
         self.endpoint = endpoint
 
     def debug(self):
-        return self._api_call('get', 'debug/')
+        return self._api_call(method='get', path='debug/')
 
     def auth(self, username, password):
         response = self._api_call(method='post', path='auth/', username=username, password=password)

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -2,7 +2,8 @@ import os
 import json
 import requests
 
-class Instamojo:
+
+class Instamojo(object):
     app_id = None
     token = None
     endpoint = None
@@ -71,18 +72,18 @@ class Instamojo:
         return response
 
     def link_edit(self, slug, # Need slug to identify link
-                     title=None, description=None, # Basic
-                     base_price=None, currency=None, # Pricing
-                     quantity=None, # Quantity
-                     start_date=None, end_date=None, venue=None, timezone=None, # Event
-                     redirect_url=None, # Redirect user to URL after successful payment
-                     webhook_url=None, # Ping your server with link data after successful payment
-                     note=None, # Show note, embed in receipt after successful payment
-                     upload_file=None, # File to upload
-                     cover_image=None, # Cover image to associate with link
-                     enable_pwyw=None,  # Enable Pay What You Want
-                     enable_sign=None,  # Enable Link Signing
-                     ):
+                  title=None, description=None, # Basic
+                  base_price=None, currency=None, # Pricing
+                  quantity=None, # Quantity
+                  start_date=None, end_date=None, venue=None, timezone=None, # Event
+                  redirect_url=None, # Redirect user to URL after successful payment
+                  webhook_url=None, # Ping your server with link data after successful payment
+                  note=None, # Show note, embed in receipt after successful payment
+                  upload_file=None, # File to upload
+                  cover_image=None, # Cover image to associate with link
+                  enable_pwyw=None,  # Enable Pay What You Want
+                  enable_sign=None,  # Enable Link Signing
+                  ):
         """Only include the parameters that you wish to change."""
         file_upload_json = self._upload_if_needed(upload_file)
         cover_image_json = self._upload_if_needed(cover_image)

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -1,5 +1,4 @@
 import os
-import json
 import requests
 
 
@@ -8,7 +7,8 @@ class Instamojo(object):
     token = None
     endpoint = None
 
-    def __init__(self, api_key, auth_token=None, endpoint='https://www.instamojo.com/api/1.1/'):
+    def __init__(self, api_key, auth_token=None,
+                 endpoint='https://www.instamojo.com/api/1.1/'):
         self.api_key = api_key
         self.auth_token = auth_token
         self.endpoint = endpoint
@@ -17,12 +17,13 @@ class Instamojo(object):
         return self._api_call(method='get', path='debug/')
 
     def auth(self, username, password):
-        response = self._api_call(method='post', path='auth/', username=username, password=password)
+        response = self._api_call(method='post', path='auth/',
+                                  username=username, password=password)
         if response['success']:
             self.token = response['token']
             return self.token
         else:
-            raise Exception(response['message']) # TODO: set custom exception?
+            raise Exception(response['message'])  # TODO: set custom exception?
 
     def links_list(self):
         response = self._api_call(method='get', path='links/')
@@ -32,20 +33,21 @@ class Instamojo(object):
         response = self._api_call(method='get', path='links/%s/' % slug)
         return response
 
-    def link_create(self, title=None, # Title is not optional
-                     description=None, # Description is not optional
-                     base_price=None,
-                     currency=None, # Pricing, is compulsory.
-                     quantity=None, # Quantity
-                     start_date=None, end_date=None, venue=None, timezone=None, # Event
-                     redirect_url=None, # Redirect user to URL after successful payment
-                     webhook_url=None, # Ping your server with link data after successful payment
-                     note=None, # Show note, embed in receipt after successful payment
-                     upload_file=None, # File to upload
-                     cover_image=None, # Cover image to associate with link
-                     enable_pwyw=None,  # Enable Pay What You Want
-                     enable_sign=None,  # Enable Link Signing
-                     ):
+    def link_create(self, title=None,  # Title is not optional
+                    description=None,  # Description is not optional
+                    base_price=None,
+                    currency=None,  # Pricing, is compulsory.
+                    quantity=None,  # Quantity
+                    start_date=None, end_date=None, venue=None,  # Event
+                    timezone=None,
+                    redirect_url=None,  # Redirect user to URL after successful payment
+                    webhook_url=None,  # Ping your server with link data after successful payment
+                    note=None,  # Show note, embed in receipt after successful payment
+                    upload_file=None,  # File to upload
+                    cover_image=None,  # Cover image to associate with link
+                    enable_pwyw=None,  # Enable Pay What You Want
+                    enable_sign=None,  # Enable Link Signing
+                    ):
 
         file_upload_json = self._upload_if_needed(upload_file)
         cover_image_json = self._upload_if_needed(cover_image)
@@ -71,16 +73,16 @@ class Instamojo(object):
         response = self._api_call(method='post', path='links/', **link_data)
         return response
 
-    def link_edit(self, slug, # Need slug to identify link
-                  title=None, description=None, # Basic
-                  base_price=None, currency=None, # Pricing
-                  quantity=None, # Quantity
-                  start_date=None, end_date=None, venue=None, timezone=None, # Event
-                  redirect_url=None, # Redirect user to URL after successful payment
-                  webhook_url=None, # Ping your server with link data after successful payment
-                  note=None, # Show note, embed in receipt after successful payment
-                  upload_file=None, # File to upload
-                  cover_image=None, # Cover image to associate with link
+    def link_edit(self, slug,  # Need slug to identify link
+                  title=None, description=None,  # Basic
+                  base_price=None, currency=None,  # Pricing
+                  quantity=None,  # Quantity
+                  start_date=None, end_date=None, venue=None, timezone=None,  # Event
+                  redirect_url=None,  # Redirect user to URL after successful payment
+                  webhook_url=None,  # Ping your server with link data after successful payment
+                  note=None,  # Show note, embed in receipt after successful payment
+                  upload_file=None,  # File to upload
+                  cover_image=None,  # Cover image to associate with link
                   enable_pwyw=None,  # Enable Pay What You Want
                   enable_sign=None,  # Enable Link Signing
                   ):
@@ -121,14 +123,13 @@ class Instamojo(object):
         response = self._api_call(method='get', path='payments/%s/' % payment_id)
         return response
 
-
     def _api_call(self, method, path, **kwargs):
         # Header: App-Id
         headers = {'X-Api-Key': self.api_key}
 
         # If available, add the Auth-token to header
         if self.auth_token:
-            headers.update({'X-Auth-Token':self.auth_token})
+            headers.update({'X-Auth-Token': self.auth_token})
 
         # Build the URL for API call
         api_path = self.endpoint + path
@@ -160,7 +161,7 @@ class Instamojo(object):
         file_upload_url = self._get_file_upload_url()['upload_url']
 
         filename = os.path.basename(filepath)
-        files = {'fileUpload':(filename, open(filepath, 'rb'))}
+        files = {'fileUpload': (filename, open(filepath, 'rb'))}
         response = requests.post(file_upload_url, files=files)
         return response.text
 
@@ -168,4 +169,4 @@ class Instamojo(object):
         """If a file is found, uploads it and returns json, else returns None"""
         if filepath:
             return self._upload_file(filepath)
-        return None # Doesn't harm being explicit.
+        return None  # Doesn't harm being explicit.

--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -133,7 +133,7 @@ class Instamojo:
         api_path = self.endpoint + path
 
         # One last sanity check
-        if api_path[-1] is not '/':
+        if not api_path.endswith('/'):
             api_path += '/'
 
         method = method.lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.3.0
+requests==2.5.3


### PR DESCRIPTION
Using `is` for comparing strings can fail because it checks identity rather than equality. It can work in CPython sometimes because it caches strings, but we cannot rely on it. The fix will work in other implementations as well like PyPy, Jython etc.