### PR TITLE
Allow file_upload param to be present while creating and editing a link

### DIFF
--- a/instamojo/api.py
+++ b/instamojo/api.py
@@ -48,12 +48,15 @@ class Instamojo(object):
                     webhook_url=None,  # Ping your server with link data after successful payment
                     note=None,  # Show note, embed in receipt after successful payment
                     upload_file=None,  # File to upload
+                    file_upload=None,  # File to upload (correct param as per documentation)
                     cover_image=None,  # Cover image to associate with link
                     enable_pwyw=None,  # Enable Pay What You Want
                     enable_sign=None,  # Enable Link Signing
                     socialpay_platforms=None,  # Choose platforms (twitter,facebook,linkedin)
                     ):
 
+        if file_upload:
+            upload_file = file_upload
         file_upload_json = self._upload_if_needed(upload_file)
         cover_image_json = self._upload_if_needed(cover_image)
 
@@ -88,12 +91,15 @@ class Instamojo(object):
                   webhook_url=None,  # Ping your server with link data after successful payment
                   note=None,  # Show note, embed in receipt after successful payment
                   upload_file=None,  # File to upload
+                  file_upload=None,  # File to upload (correct param as per documentation)
                   cover_image=None,  # Cover image to associate with link
                   enable_pwyw=None,  # Enable Pay What You Want
                   enable_sign=None,  # Enable Link Signing
                   socialpay_platforms=None,  # Choose platforms (twitter,facebook,linkedin)
                   ):
         """Only include the parameters that you wish to change."""
+        if file_upload:
+            upload_file = file_upload
         file_upload_json = self._upload_if_needed(upload_file)
         cover_image_json = self._upload_if_needed(cover_image)
 


### PR DESCRIPTION
Hi
According to the [python API docs for file upload while create](https://github.com/instamojo/instamojo-py#file-and-cover-image), `file_upload` is listed as parameter to specify file path with. However, the `api.py` accepts `upload_file` as param.

Didn't update the README.md since `file_upload_json` is the actual parameter sent to api. As `cover_image` is the parameter for `cover_image_json`, so should `file_upload` for `file_upload_json`. I think. :confused: 

This PR patches an additional `file_upload` parameter, which if present overrides `upload_file` and continues the flow. `upload_file` remains present for backward compatibility. 